### PR TITLE
Add osx_arm64 build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 mkdir build && cd build
 cmake ${SRC_DIR}                     \
+    ${CMAKE_ARGS}                    \
     -DCMAKE_PREFIX_PATH=${PREFIX}    \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DASP_DEPS_DIR=${PREFIX}         \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d5ed3d52e3b9121fde98269994586d46a21f15bf2e2a1c36bedca48f1cea4323
 
 build:
-  number: 0
+  number: 1
   skip: win
   script: build.sh
 


### PR DESCRIPTION
This feedstock currently builds only linux_64 and osx_64; there is no Apple Silicon package because the feedstock has never been re-rendered for osx_arm64. The recipe build.sh was also missing ${CMAKE_ARGS}, so the conda-forge cross-compile toolchain was never applied to the cmake call. This PR adds ${CMAKE_ARGS} and bumps the build number. A rerender will generate the osx_arm64 variant.

@conda-forge-admin, please rerender