### PR TITLE
Add osx_arm64 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -15,6 +15,13 @@ jobs:
         build_workspace_dir: ~/miniforge3/conda-bld
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,43 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+flann:
+- 1.9.2
+libboost_devel:
+- '1.90'
+libgdal:
+- '3.13'
+libjpeg_turbo:
+- '3'
+libopencv:
+- 4.13.0
+libpng:
+- '1.6'
+libtiff:
+- '4.7'
+macos_machine:
+- arm64-apple-darwin20.0.0
+openblas:
+- 0.3.*
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About visionworkbench-feedstock
 ===============================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/visionworkbench-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/vw-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/visionworkbench/visionworkbench
 
@@ -22,8 +22,8 @@ Current build status
 <table><tr>
     <td>GitHub Actions</td>
     <td>
-      <a href="https://github.com/conda-forge/visionworkbench-feedstock/actions/workflows/conda-build.yml">
-        <img src="https://github.com/conda-forge/visionworkbench-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      <a href="https://github.com/conda-forge/vw-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/vw-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
       </a>
     </td>
   </tr>
@@ -33,8 +33,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26031&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/visionworkbench-feedstock?branchName=main">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vw-feedstock?branchName=main">
           </a>
         </summary>
         <table>
@@ -42,8 +42,8 @@ Current build status
           <tbody><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26031&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/visionworkbench-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vw-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,6 @@
 conda_build_tool: rattler-build
+build_platform:
+  osx_arm64: osx_64
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 mkdir build && cd build
 cmake ${SRC_DIR}                     \
+    ${CMAKE_ARGS}                    \
     -DCMAKE_PREFIX_PATH=${PREFIX}    \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DASP_DEPS_DIR=${PREFIX}         \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d5ed3d52e3b9121fde98269994586d46a21f15bf2e2a1c36bedca48f1cea4323
 
 build:
-  number: 0
+  number: 1
   skip: win
   script: build.sh
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,8 +34,12 @@ requirements:
     - libtiff
 
 tests:
-  - script:
-      - hillshade $PREFIX/share/vw/tests/tinyDemAN.tif
+  # Skip when cross-compiling (e.g. osx_arm64 built on osx_64); the target
+  # binary cannot run on the build host.
+  - if: target_platform == build_platform
+    then:
+      script:
+        - hillshade $PREFIX/share/vw/tests/tinyDemAN.tif
 
 about:
   homepage: https://github.com/visionworkbench/visionworkbench


### PR DESCRIPTION
This feedstock builds only linux_64 and osx_64; there is no Apple Silicon package because it has never been re-rendered for osx_arm64. The recipe build.sh was also missing ${CMAKE_ARGS}, so the conda-forge cross-compile toolchain was never applied to the cmake call. This PR adds ${CMAKE_ARGS} and bumps the build number. A rerender will generate the osx_arm64 variant.

@conda-forge-admin, please rerender